### PR TITLE
Add `/daily list` command for listing channel bonuses in a guild

### DIFF
--- a/pg13/cogs/dailies.py
+++ b/pg13/cogs/dailies.py
@@ -159,8 +159,10 @@ class DailyBonuses(
 
         formatted_bonuses = []
         for bonus in guild_dailies:
-            channel_mention = (
-                interaction.guild.get_channel(bonus["channel"]) or "<deleted channel>"
+            channel_mention = getattr(
+                interaction.guild.get_channel(bonus["channel"]),
+                "mention",
+                "<deleted channel>",
             )
             attachment_comment = (
                 " (picture/link required)" if bonus["attachment"] else ""
@@ -191,7 +193,7 @@ class DailyBonuses(
             deleted_channels = [
                 bonus["channel"]
                 for bonus in daily_channels
-                if interaction.guild.get(bonus["channel"]) is None
+                if interaction.guild.get_channel(bonus["channel"]) is None
             ]
 
             await con.execute(

--- a/pg13/cogs/dailies.py
+++ b/pg13/cogs/dailies.py
@@ -159,7 +159,8 @@ class DailyBonuses(
 
         if not guild_dailies:
             await interaction.response.send_message(
-                "There aren't any daily channel bonuses in this server yet :), ephemeral=True"
+                "There aren't any daily channel bonuses in this server yet :)",
+                ephemeral=True,
             )
 
         else:

--- a/pg13/cogs/dailies.py
+++ b/pg13/cogs/dailies.py
@@ -147,6 +147,58 @@ class DailyBonuses(
                 f"Succesfully detached daily bonus from channel #{channel.name}"
             )
 
+    @app_commands.command(
+        name="list", description="List all channel daily bonuses in this server."
+    )
+    async def daily_list(self, interaction: discord.Interaction):
+        async with self.db_pool.acquire() as con:
+            guild_dailies = await con.fetch(
+                "SELECT channel, points, attachment FROM channel_bonuses WHERE guild = $1",
+                interaction.guild_id,
+            )
+
+        formatted_bonuses = []
+        for bonus in guild_dailies:
+            channel_mention = (
+                interaction.guild.get_channel(bonus["channel"]) or "<deleted channel>"
+            )
+            attachment_comment = (
+                " (picture/link required)" if bonus["attachment"] else ""
+            )
+            formatted_bonuses.append(
+                f"{channel_mention}: {bonus['points']} points{attachment_comment}"
+            )
+
+        await interaction.response.send_message(
+            embed=discord.Embed(
+                title=f"{interaction.guild.name} Channel Bonuses",
+                description="\n".join(formatted_bonuses),
+            )
+        )
+
+    @app_commands.command(
+        name="clean-deleted",
+        description="Cleans up daily bonuses from deleted channels",
+    )
+    @app_commands.check(admin_check)
+    async def daily_clean_deleted(self, interaction: discord.Interaction):
+        async with self.db_pool.acquire() as con:
+            daily_channels = await con.fetch(
+                "SELECT channel FROM channel_bonuses WHERE guild = $1",
+                interaction.guild_id,
+            )
+
+            deleted_channels = [
+                bonus["channel"]
+                for bonus in daily_channels
+                if interaction.guild.get(bonus["channel"]) is None
+            ]
+
+            await con.execute(
+                "DELETE FROM channel_bonuses WHERE channel = ANY($1::BIGINT[])",
+                deleted_channels,
+            )
+
     @commands.Cog.listener()
     async def on_message(self, message):
         if message.author.bot:


### PR DESCRIPTION
I also added the `/daily clean-deleted` command to remove db entries for bonuses from deleted channels which I realized could exist while writing `/daily list`.