### PR TITLE
Add a README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PG-13 - the Discord point bot you'll never need
+# PG-13
 
 I don't expect this to be useful to anyone, but hey, if it is that's great :)
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Just add the following to your system configuration flake:
 
 ```nix
 {
-  inputs.pg-13.url = github:5t0n3/pg-13;
+  inputs.pg-13.url = "github:5t0n3/pg-13";
 
-  outputs = { self, nixpkgs, pg-13 }:
+  outputs = { self, nixpkgs, pg-13 }: {
     nixosConfigurations.yourhostname = nixpkgs.lib.nixosSystem {
       system = "<your system/architecture>";
       modules = [

--- a/README.md
+++ b/README.md
@@ -1,0 +1,83 @@
+# PG-13 - the Discord point bot you'll never need
+
+I don't expect this to be useful to anyone, but hey, if it is that's great :)
+
+## Functionality
+
+TODO
+
+## Installation
+
+If you're using NixOS, something like [agenix](https://github.com/ryantm/agenix)
+can be useful for managing your PG-13 configuration. Just set
+`services.pg-13.configFile` to be the `path` attribute of the corresponding
+secret.
+
+### NixOS with flakes (recommended)
+
+Just add the following to your system configuration flake:
+
+```nix
+{
+  inputs.pg-13.url = github:5t0n3/pg-13;
+
+  outputs = { self, nixpkgs, pg-13 }:
+    nixosConfigurations.yourhostname = nixpkgs.lib.nixosSystem {
+      system = "<your system/architecture>";
+      modules = [
+        pg-13.nixosModules.default
+        ({
+          services.pg-13.enable = true;
+
+          # optional but recommended
+          # (defaults to /var/lib/pg-13/config.toml)
+          # services.pg-13.configFile = <path/to/your/config.toml>;
+        })
+      ];
+    };
+  };
+}
+```
+
+### NixOS (no flakes)
+
+Add the following to your system configuration:
+
+```nix
+{ pkgs, ... }:
+let
+  pg-13 = import (pkgs.fetchFromGitHub {
+    owner = "5t0n3";
+    repo = "pg-13";
+    rev = "v1.0.0"; # or a commit hash
+    sha256 = "<repository hash>"; # obtained using nix-prefetch-url
+  });
+in {
+  imports = [ pg-13.nixosModules.default ];
+
+  services.pg-13.enable = true;
+
+  # optional but recommended
+  # (defaults to /var/lib/pg-13/config.toml)
+  # services.pg-13.configFile = "<path/to/your/config.toml>";
+}
+```
+
+You can probably also add this repository as a channel, if you'd like.
+
+### Other operating systems
+
+You'll need to install a few things in order to get PG-13 running on other
+operating systems, namely PostgreSQL, Python (3.10+), and
+[poetry](https://python-poetry.org/), a Python package manager. PG-13 also
+depends on systemd, so if your operating system doesn't use it then you're out
+of luck unfortunately. There might also be a couple more things to install, but
+given that I use NixOS I don't know what they might be :)
+
+On the Postgres side, PG-13 expects the `pg_13` database to exist and to have
+all privileges in modifying it. When running the bot itself, the bot
+configuration should either be placed in `config.toml` in the working directory
+or supplied via the `CONFIG_PATH` environment variable. I'd recommend running
+PG-13 as a systemd service, as that way you don't have to worry about manually
+starting it up whenever the computer it's running on is restarted. You can look
+at flake.nix for a good starting point for doing this.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,23 @@
 # PG-13
 
+[![built with nix](https://builtwithnix.org/badge.svg)](https://builtwithnix.org)
+
+A Discord bot that keeps track of points from a variety of sources.
+
 I don't expect this to be useful to anyone, but hey, if it is that's great :)
 
-## Functionality
+## Features
 
-TODO
+- **Score tracking** through server-specific leaderboards
+- **Manual score management** when you want to ~~punish your enemies~~ reward
+  specific users
+- **Assignment of special roles** to the users with the most points
+- **Daily point rewards** for both messages in configurable text channels and
+  via a command
+- **Game nights** with points awarded based on how long someone stays in a call
+  for
+- Something about the [**Door to Darkness**](pg13/cogs/door_to_darkness.py), if
+  you so desire :)
 
 ## Installation
 

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,6 @@
+(import (let lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+in fetchTarball {
+  url =
+    "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+  sha256 = lock.nodes.flake-compat.locked.narHash;
+}) { src = ./.; }).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1662019588,
@@ -18,6 +34,7 @@
     },
     "root": {
       "inputs": {
+        "flake-compat": "flake-compat",
         "nixpkgs": "nixpkgs",
         "utils": "utils"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,10 +2,15 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     utils.url = "github:numtide/flake-utils";
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
   };
 
-  outputs = { self, nixpkgs, utils }:
-    utils.lib.eachSystem [ "x86_64-linux" ] (system:
+  outputs = { self, nixpkgs, utils, flake-compat }:
+    utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" "i686-linux" ]
+    (system:
       let pkgs = nixpkgs.legacyPackages.${system};
       in {
         packages.pg-13 = pkgs.poetry2nix.mkPoetryApplication {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "pg13"
 version = "1.0.0"
 description = "A needlessly complicated point system bot for Discord."
 authors = ["Zane Othman-Gomez <zane.othman@gmail.com>"]
-license = "ISC"
+license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = "^3.10"


### PR DESCRIPTION
A default.nix for this repository was also added (using flake-compat) so pg-13 can be installed on NixOS when not using flakes.